### PR TITLE
Add asdf initialization to shell configuration

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -84,3 +84,5 @@ alias -g gti="git"
 export PATH="/opt/homebrew/opt/mysql@5.7/bin:$PATH"
 
 
+# asdf Goを使いたくてinstallした
+. /opt/homebrew/opt/asdf/libexec/asdf.sh

--- a/.zshrc
+++ b/.zshrc
@@ -86,3 +86,8 @@ export PATH="/opt/homebrew/opt/mysql@5.7/bin:$PATH"
 
 # asdf Goを使いたくてinstallした
 . /opt/homebrew/opt/asdf/libexec/asdf.sh
+eval "$(direnv hook zsh)"
+
+# aqua用の記述
+export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH"
+


### PR DESCRIPTION
## Summary
- asdf経由でGoを使用するため、.zshrcにasdfの初期化コードを追加

## Test plan
- [ ] ターミナルを再起動して、asdfコマンドが利用可能であることを確認
- [ ] `asdf --version`が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)